### PR TITLE
Bugfix/fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,14 @@
     }
   ],
   "require": {
-      "php": ">=5.3.0"
+      "php": ">=5.4"
   },
   "autoload": {
     "files": [
       "src/IndieWeb/link_rel_parser.php"
     ]    
+  },
+  "require-dev": {
+    "yoast/phpunit-polyfills": "^1.0"
   }
 }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -1,9 +1,8 @@
 <?php
-class BasicTest extends PHPUnit_Framework_TestCase {
 
-  public function setUp() {
-  }
+use PHPUnit\Framework\TestCase;
 
+class BasicTest extends TestCase {
   private function _testEquals($expected, $headers) {
     $result = IndieWeb\http_rels($headers);
     $this->assertEquals($expected, $result);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 
-require dirname(__DIR__) . '/src/IndieWeb/link_rel_parser.php';
+require_once dirname(__DIR__) . '/src/IndieWeb/link_rel_parser.php';
 


### PR DESCRIPTION
I Noticed this 2018 commit is broken, and that tests cannot be run against PHP 8.1. It also does not document which PHP Unit version the tests were for.

This does a few things:

- Yoast polyfill so PHP 5.4 - 8.1 compatible PHPUnit should "just work"
- use namespace for TestCase instead of older globally available classname
- Basic gitignore for the vendor and lock file
- update composer.json to indicate PHP 5.4+ (this is very old)
- require_once instead of require (seems to avoid double-loading file)

I Can make a separate PR if required / desired to update the GitHub action